### PR TITLE
fix symbolic links on unix

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -12,7 +12,8 @@ pub fn executables() -> Result<Vec<Executable>, VarError> {
         let mut exes = Vec::new();
         if let Ok(dir) = fs::read_dir(path) {
             for entry in dir.flatten() {
-                if let Ok(metadata) = entry.metadata() {
+                // We need to call metadata on the path to follow symbolic links
+                if let Ok(metadata) = entry.path().metadata() {
                     if !metadata.is_file() {
                         continue;
                     }
@@ -59,4 +60,9 @@ pub fn executables() -> Result<Vec<Executable>, VarError> {
         });
 
     Ok(executables)
+}
+
+#[test]
+fn test() {
+    executables();
 }


### PR DESCRIPTION
Previously executables that are just links to another executable (kind of like aliases) would not have been found.

This was the case for cargo in my installation for example.

If you don't mind, I'd love to have this pr labeled as `hacktoberfest-accepted`.
