### PR TITLE
unique executables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "executable-finder"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "rayon",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ documentation = "https://docs.rs/executable-finder"
 rayon = { version = "1.5.3", optional = true }
 
 [features]
-default = []
+default = ["rayon"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ documentation = "https://docs.rs/executable-finder"
 rayon = { version = "1.5.3", optional = true }
 
 [features]
-default = ["rayon"]
+default = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,12 +10,12 @@ use std::{
 #[cfg(unix)]
 mod unix;
 #[cfg(unix)]
-use unix::{search_dir, split_paths};
+use unix::{search_dir, split_path};
 
 #[cfg(windows)]
 mod windows;
 #[cfg(windows)]
-use windows::{search_dir, split_paths};
+use windows::{search_dir, split_path};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Executable {
@@ -28,7 +28,7 @@ pub struct Executable {
 /// **Note:** this does not filter out duplicates
 pub fn executables() -> Result<Vec<Executable>, VarError> {
     let path = env::var("PATH")?;
-    let paths = split_paths(&path);
+    let paths = split_path(&path);
 
     let search_dir = search_dir()?;
 
@@ -56,7 +56,7 @@ pub fn executables() -> Result<Vec<Executable>, VarError> {
 pub fn unique_executables() -> Result<HashMap<String, Executable>, VarError> {
     let path = env::var("PATH")?;
 
-    Ok(split_paths(&path)
+    Ok(split_path(&path)
         .filter_map(search_dir()?)
         .fold(HashMap::new(), |mut a, b| {
             a.extend(b.into_iter().map(|e| (e.name.clone(), e)));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,70 @@
-use std::path::PathBuf;
+#[cfg(feature = "rayon")]
+use rayon::prelude::*;
+
+use std::{
+    collections::HashMap,
+    env::{self, VarError},
+    path::PathBuf,
+};
 
 #[cfg(unix)]
 mod unix;
 #[cfg(unix)]
-pub use unix::executables;
+use unix::{search_dir, split_paths};
 
 #[cfg(windows)]
 mod windows;
 #[cfg(windows)]
-pub use windows::executables;
+use windows::{search_dir, split_paths};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Executable {
     pub name: String,
     pub path: PathBuf,
+}
+
+/// Lists all executables on PATH
+///
+/// **Note:** this does not filter out duplicates
+pub fn executables() -> Result<Vec<Executable>, VarError> {
+    let path = env::var("PATH")?;
+    let paths = split_paths(&path);
+
+    let search_dir = search_dir()?;
+
+    #[cfg(feature = "rayon")]
+    let executables = paths
+        .collect::<Vec<_>>()
+        .into_par_iter()
+        .filter_map(search_dir)
+        .reduce(Vec::new, |mut a, b| {
+            a.extend_from_slice(&b);
+            a
+        });
+    #[cfg(not(feature = "rayon"))]
+    let executables = paths.filter_map(search_dir).fold(Vec::new(), |mut a, b| {
+        a.extend_from_slice(&b);
+        a
+    });
+
+    Ok(executables)
+}
+
+/// Handles precedence i.e. an entry later in PATH will override an earlier one
+///
+/// **Note:** this will never use rayon
+pub fn unique_executables() -> Result<HashMap<String, Executable>, VarError> {
+    let path = env::var("PATH")?;
+
+    Ok(split_paths(&path)
+        .filter_map(search_dir()?)
+        .fold(HashMap::new(), |mut a, b| {
+            a.extend(b.into_iter().map(|e| (e.name.clone(), e)));
+            a
+        }))
+}
+
+#[test]
+fn test() {
+    executables().unwrap();
 }

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,15 +1,11 @@
-use std::{env::VarError, fs, os::unix::fs::PermissionsExt};
+use std::{env::VarError, os::unix::fs::PermissionsExt, path::PathBuf};
 
 use crate::Executable;
 
-pub fn split_path(path: &str) -> impl Iterator<Item = &str> {
-    path.split(':')
-}
-
-pub fn search_dir() -> Result<fn(&str) -> Option<Vec<Executable>>, VarError> {
-    Ok(|path: &str| -> Option<Vec<Executable>> {
+pub fn search_dir() -> Result<fn(PathBuf) -> Option<Vec<Executable>>, VarError> {
+    Ok(|path: PathBuf| -> Option<Vec<Executable>> {
         let mut exes = Vec::new();
-        if let Ok(dir) = fs::read_dir(path) {
+        if let Ok(dir) = path.read_dir() {
             for entry in dir.flatten() {
                 // We need to call metadata on the path to follow symbolic links
                 if let Ok(metadata) = entry.path().metadata() {

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -2,7 +2,7 @@ use std::{env::VarError, fs, os::unix::fs::PermissionsExt};
 
 use crate::Executable;
 
-pub fn split_paths(path: &str) -> impl Iterator<Item = &str> {
+pub fn split_path(path: &str) -> impl Iterator<Item = &str> {
     path.split(':')
 }
 

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -2,7 +2,7 @@ use std::{collections::HashSet, env, env::VarError, fs};
 
 use crate::Executable;
 
-pub fn split_paths(path: &str) -> impl Iterator<Item = &str> {
+pub fn split_path(path: &str) -> impl Iterator<Item = &str> {
     path.split(';')
 }
 

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,12 +1,8 @@
-use std::{collections::HashSet, env, env::VarError, fs};
+use std::{collections::HashSet, env, env::VarError, path::PathBuf};
 
 use crate::Executable;
 
-pub fn split_path(path: &str) -> impl Iterator<Item = &str> {
-    path.split(';')
-}
-
-pub fn search_dir() -> Result<impl Fn(&str) -> Option<Vec<Executable>>, VarError> {
+pub fn search_dir() -> Result<impl Fn(PathBuf) -> Option<Vec<Executable>>, VarError> {
     let pathext = env::var("PATHEXT")?;
 
     let exts: HashSet<String> = pathext
@@ -14,9 +10,9 @@ pub fn search_dir() -> Result<impl Fn(&str) -> Option<Vec<Executable>>, VarError
         .map(|s| s.trim_start_matches('.').to_string())
         .collect();
 
-    Ok(move |path: &str| -> Option<Vec<Executable>> {
+    Ok(move |path: PathBuf| -> Option<Vec<Executable>> {
         let mut exes = Vec::new();
-        if let Ok(dir) = fs::read_dir(path) {
+        if let Ok(dir) = path.read_dir() {
             for entry in dir.flatten() {
                 if let Ok(metdata) = entry.metadata() {
                     if !metdata.is_file() {


### PR DESCRIPTION
Added a new function called `unique_executables` that not only filters out duplicates and replaces the earlier entries with later ones, but also provides a hashmap making it easy to access those both by executable name and as a list.

If you don't mind, I'd love to have this pr labeled as `hacktoberfest-accepted`.